### PR TITLE
Sane option parsing

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -3,7 +3,12 @@
 var http = require('http'),
     qs = require('querystring');
 
-exports.run = function(callback, port, host) {
+exports.run = function(options, cb) {
+  options = options !== undefined ? options : {};
+  var port = options.port !== undefined ? options.port : (process.env['COUCH_EMAIL_AUTH_PORT'] || 1337),
+      host = options.host !== undefined ? options.host : '127.0.0.1',
+      callback = cb !== undefined ? function() { cb(server); } : function() {};
+
   var server = http.createServer(function(req, resp) {
     var EMAIL_REGEX = /.+@.+\..+/;
 
@@ -37,7 +42,7 @@ exports.run = function(callback, port, host) {
     }
   });
 
-  server.listen(port !== undefined ? port : (process.env['COUCH_EMAIL_AUTH_PORT'] || 1337), host !== undefined ? host : '127.0.0.1', callback !== undefined ? function() { callback(server); } : function() {});
+  server.listen(port, host, callback);
 
   return server;
 }

--- a/test/api.js
+++ b/test/api.js
@@ -4,15 +4,18 @@ var test = require('tape'),
     s = require('../lib/server'),
     testRequest = require('./test_helper').testRequest;
 
-var address, port, server;
+var address = '127.0.0.1', port = 0, server;
 
 test('setup', function(t) {
-  s.run(function(instance) {
+  s.run({
+    port: port,
+    host: address
+  }, function(instance) {
     server = instance;
     address = server.address().address;
     port = server.address().port;
     t.end();
-  }, 0, '127.0.0.1');
+  });
 });
 
 test('POST /', function(t) {


### PR DESCRIPTION
Pass options as an Object first, then pass the callback.

It looks a bit like the standard API of `request` but when using node it is always more idiomatic to first pass in data, and then the callback.

Greetings from Lisbon (where we have bolt&thunder currently)
