### PR TITLE
Don't use tokens as password

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -82,8 +82,11 @@ function handlePost(req, resp) {
       }
 
       authToken = crypto.randomBytes(32).toString('hex');
-      setPassword(doc, authToken);
-      doc.timestamp = new Date().getTime();
+      doc.couch_email_auth_secret = crypto.randomBytes(32).toString('hex');
+      setPassword(doc, authToken + doc.couch_email_auth_secret);
+
+      doc.couch_email_auth_timestamp = new Date().getTime();
+
       if (username) {
         doc.username = username;
       }
@@ -146,21 +149,24 @@ function handleGet(req, resp) {
   }
 
   db.get('org.couchdb.user:' + query.email, function(err, doc) {
-    var now = new Date().getTime();
+    var now = new Date().getTime(),
+        password;
 
-    if (err || !doc.timestamp) {
+    if (err || !doc.couch_email_auth_timestamp) {
       resp.statusCode = 401;
       resp.end('{"error":"unauthorized"}');
       return;
     }
 
-    if (doc.timestamp + config.sessionTimeout * 1000 < now) {
+    if (doc.couch_email_auth_timestamp + config.sessionTimeout * 1000 < now) {
       resp.statusCode = 401;
       resp.end('{"error":"unauthorized"}');
       return;
     }
 
-    nano.auth(query.email, query.token, function (err, body, headers) {
+    password = query.token + doc.couch_email_auth_secret;
+
+    nano.auth(query.email, password, function (err, body, headers) {
       if (err || !headers['set-cookie']) {
         resp.statusCode = 401;
         resp.end('{"error":"unauthorized"}');
@@ -169,7 +175,7 @@ function handleGet(req, resp) {
 
       // now let's make sure that the token cannot be used again
 
-      doc.timestamp = 0;
+      doc.couch_email_auth_timestamp = 0;
 
       db.insert(doc, function(err, d) {
         if (err) {

--- a/test/api.js
+++ b/test/api.js
@@ -145,7 +145,8 @@ test('POST /', function(t) {
       db.get('org.couchdb.user:foobator@example.com', function(err, doc) {
         t.notOk(err, 'document missing');
         t.equal(doc.name, 'foobator@example.com');
-        t.equal(typeof doc.timestamp, 'number');
+        t.equal(typeof doc.couch_email_auth_secret, 'string');
+        t.equal(typeof doc.couch_email_auth_timestamp, 'number');
         t.end();
       });
     });
@@ -165,7 +166,8 @@ test('POST /', function(t) {
         t.notOk(err, 'document missing');
         t.equal(doc.username, 'Rocko Artischocko');
         t.equal(doc.name, 'rockoartischocko@example.com');
-        t.equal(typeof doc.timestamp, 'number');
+        t.equal(typeof doc.couch_email_auth_secret, 'string');
+        t.equal(typeof doc.couch_email_auth_timestamp, 'number');
         t.end();
       });
     });


### PR DESCRIPTION
In order to avoid that tokens can be used as password for direct
authenticating against CouchDB's `/_session` endpoint, we now derive the
password from a combination of the token and a secret value that is
stored in the user document.

Also, we now prefix the field names for the secret and timestamp values
that we store in the user document with `couch_email_auth_` each (i.e.,
`couch_email_auth_secret`, `couch_email_auth_timestamp`).
