### PR TITLE
Redirect after successful authentication

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -184,8 +184,9 @@ function handleGet(req, resp) {
           return;
         }
 
+        resp.statusCode = 302;
+        resp.setHeader('Location', config.redirectLocation);
         resp.setHeader('Set-Cookie', headers['set-cookie']);
-        resp.statusCode = 200;
         resp.end(JSON.stringify(body));
       });
     });

--- a/test/api.js
+++ b/test/api.js
@@ -276,11 +276,13 @@ test('GET /', function(t) {
       request({
         method: 'GET',
         uri: link,
-        json: true
+        json: true,
+        followRedirect: false
       }, function(err, response, body) {
-        t.equal(response.statusCode, 200);
+        t.equal(response.statusCode, 302);
         t.ok(body.ok);
         t.ok(body.name, email);
+        t.equal(response.headers['location'], config.redirectLocation);
         t.ok(response.headers['set-cookie']);
         t.end();
       });
@@ -306,9 +308,10 @@ test('GET /', function(t) {
       request({
         method: 'GET',
         uri: link,
-        json: true
+        json: true,
+        followRedirect: false
       }, function(err, response, body) {
-        t.equal(response.statusCode, 200);
+        t.equal(response.statusCode, 302);
         t.ok(body.ok);
 
         request({

--- a/test/fixtures/integrationtestrc
+++ b/test/fixtures/integrationtestrc
@@ -3,6 +3,7 @@ port=0
 couchDbBaseUrl=http://admin:secret@localhost:5984
 usersDb=test_suite_users
 sessionTimeout=1
+redirectLocation=http://localhost:5984/
 
 [smtp]
   port=2525


### PR DESCRIPTION
Instead of sending a response with status code `200`, the server now
sends status code `302` and sets the Location header to the
`redirectLocation` value that is retrieved from the configuration.

Closes #24.
