### PR TITLE
update testmatrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: node_js
 node_js:
-  - "0.11"
   - "0.10"
+  - "0.12"
+  - iojs
 
 before_script:
   "./create_admin_user.sh"


### PR DESCRIPTION
0.12 got released and we also can test with iojs
0.11 was the old unstable, it probably does not make sense to test
for it any more (even: stable, odd version: unstable)